### PR TITLE
feat: add generater init with option

### DIFF
--- a/protoc-gen-openapiv2/generator/generator.go
+++ b/protoc-gen-openapiv2/generator/generator.go
@@ -69,6 +69,7 @@ func (g *Generator) Gen(req *pluginpb.CodeGeneratorRequest, onlyRPC bool) (*plug
 	if reg == nil {
 		reg = NewGenerator().reg
 	}
+	reg.SetGenerateRPCMethods(onlyRPC)
 	if err := reg.SetRepeatedPathParamSeparator("csv"); err != nil {
 		return nil, err
 	}
@@ -90,7 +91,6 @@ func (g *Generator) Gen(req *pluginpb.CodeGeneratorRequest, onlyRPC bool) (*plug
 		}
 		targets = append(targets, f)
 	}
-
 	out, err := gen.Generate(targets)
 	if err != nil {
 		return nil, err

--- a/protoc-gen-openapiv2/generator/generator_test.go
+++ b/protoc-gen-openapiv2/generator/generator_test.go
@@ -28,3 +28,30 @@ func Test_Gen(t *testing.T) {
 		fmt.Println(*file.Content)
 	}
 }
+
+func Test_NewGenerator(t *testing.T) {
+	var err error
+	f, err := os.Open("./req.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := codegenerator.ParseRequest(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := NewGenerator(
+		DisableDefaultErrors(true),
+		UseJSONNamesForFields(false),
+		EnumsAsInts(true),
+		RecursiveDepth(2048),
+	)
+
+	resp, err := g.Gen(req, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range resp.File {
+		fmt.Println(*file.Content)
+	}
+}


### PR DESCRIPTION
https://github.com/go-kratos/swagger-api/issues/5#issue-945165491

I want pass some flag to `Gen` function. I well go to update [go-kratos/swagger-api](https://github.com/go-kratos/swagger-api) if this pr be merged.